### PR TITLE
hotfix: Updated domain references back to deepwiki.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.8] - YYYY-MM-DD
+## [0.0.9] - 2025-05-12
+
+### Changed
+- Updated domain again and changed back to `deepwiki.com` (by @KerneggerTim).
+
+## [0.0.8] - 2025-05-09
 
 ### Changed
 - Updated to support `deepwiki.org` instead of `deepwiki.com` (by @KerneggerTim).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It takes a Deepwiki URL via MCP, crawls all relevant pages, converts them to Mar
 
 ## Features
 
-- 🔒 **Domain Safety**: Only processes URLs from deepwiki.org
+- 🔒 **Domain Safety**: Only processes URLs from deepwiki.com
 - 🧹 **HTML Sanitization**: Strips headers, footers, navigation, scripts, and ads
 - 🔗 **Link Rewriting**: Adjusts links to work in Markdown
 - 📄 **Multiple Output Formats**: Get one document or structured pages
@@ -31,13 +31,13 @@ deepwiki fetch i want to understand how X works
 
 Fetch complete Documentation (Default)
 ```
-use deepwiki https://deepwiki.org/shadcn-ui/ui
-use deepwiki multiple pages https://deepwiki.org/shadcn-ui/ui
+use deepwiki https://deepwiki.com/shadcn-ui/ui
+use deepwiki multiple pages https://deepwiki.com/shadcn-ui/ui
 ```
 
 Single Page
 ```
-use deepwiki fetch single page https://deepwiki.org/tailwindlabs/tailwindcss/2.2-theme-system
+use deepwiki fetch single page https://deepwiki.com/tailwindlabs/tailwindcss/2.2-theme-system
 ```
 
 Get by shortform
@@ -80,7 +80,7 @@ The package registers a tool named `deepwiki_fetch` that you can use with any MC
 {
   "action": "deepwiki_fetch",
   "params": {
-    "url": "https://deepwiki.org/user/repo",
+    "url": "https://deepwiki.com/user/repo",
     "mode": "aggregate",
     "maxDepth": "1"
   }
@@ -134,7 +134,7 @@ The package registers a tool named `deepwiki_fetch` that you can use with any MC
 {
   "status": "error",
   "code": "DOMAIN_NOT_ALLOWED",
-  "message": "Only deepwiki.org domains are allowed"
+  "message": "Only deepwiki.com domains are allowed"
 }
 ```
 
@@ -146,7 +146,7 @@ The package registers a tool named `deepwiki_fetch` that you can use with any MC
   "data": "# Page Title\n\nPage content...",
   "errors": [
     {
-      "url": "https://deepwiki.org/user/repo/page2",
+      "url": "https://deepwiki.com/user/repo/page2",
       "reason": "HTTP error: 404"
     }
   ],
@@ -161,9 +161,9 @@ The package registers a tool named `deepwiki_fetch` that you can use with any MC
 When using the tool, you'll receive progress events during crawling:
 
 ```
-Fetched https://deepwiki.org/user/repo: 12500 bytes in 450ms (status: 200)
-Fetched https://deepwiki.org/user/repo/page1: 8750 bytes in 320ms (status: 200)
-Fetched https://deepwiki.org/user/repo/page2: 6200 bytes in 280ms (status: 200)
+Fetched https://deepwiki.com/user/repo: 12500 bytes in 450ms (status: 200)
+Fetched https://deepwiki.com/user/repo/page1: 8750 bytes in 320ms (status: 200)
+Fetched https://deepwiki.com/user/repo/page2: 6200 bytes in 280ms (status: 200)
 ```
 
 ## Local Development - Installation
@@ -206,7 +206,7 @@ curl -X POST http://localhost:3000/mcp \
     "id": "req-1",
     "action": "deepwiki_fetch",
     "params": {
-      "url": "https://deepwiki.org/user/repo",
+      "url": "https://deepwiki.com/user/repo",
       "mode": "aggregate"
     }
   }'

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.0.8",
   "packageManager": "pnpm@9.14.4+sha512.c8180b3fbe4e4bca02c94234717896b5529740a6cbadf19fa78254270403ea2f27d4e1d46a08a0f56c89b63dc8ebfd3ee53326da720273794e6200fcf0d184ab",
-  "description": "MCP server for fetch deepwiki.org and turn content into LLM readable markdown",
+  "description": "MCP server for fetch deepwiki.com and turn content into LLM readable markdown",
   "contributors": [
     {
       "name": "Kevin Kern",

--- a/src/schemas/deepwiki.ts
+++ b/src/schemas/deepwiki.ts
@@ -7,7 +7,7 @@ export const ModeEnum = z.enum(['aggregate', 'pages'])
 /* ---------- request ---------- */
 
 export const FetchRequest = z.object({
-  /** Deepwiki repo URL, eg https://deepwiki.org/user/repo */
+  /** Deepwiki repo URL, eg https://deepwiki.com/user/repo */
   url: z.string().describe('should be a URL, owner/repo name (e.g. "vercel/ai"), a two-word "owner repo" form (e.g. "vercel ai"), or a single library keyword'),
   /** Crawl depth limit: 0 means only the root page */
   maxDepth: z.number().int().min(0).max(1).default(1).describe('Can fetch a single site => maxDepth 0 or multiple/all sites => maxDepth 1'),

--- a/src/tools/deepwiki.ts
+++ b/src/tools/deepwiki.ts
@@ -14,7 +14,7 @@ import { FetchRequest } from '../schemas/deepwiki'
 export function deepwikiTool({ mcp }: McpToolContext) {
   mcp.tool(
     'deepwiki_fetch',
-    'Fetch a deepwiki.org repo and return Markdown',
+    'Fetch a deepwiki.com repo and return Markdown',
     FetchRequest.shape,
     async (input) => {
       // Normalize the URL to support short forms
@@ -65,7 +65,7 @@ export function deepwikiTool({ mcp }: McpToolContext) {
           }
 
           // At this point url should be "owner/repo"
-          url = `https://deepwiki.org/${url}`
+          url = `https://deepwiki.com/${url}`
         }
 
         normalizedInput.url = url
@@ -93,11 +93,11 @@ export function deepwikiTool({ mcp }: McpToolContext) {
         return err
       }
 
-      if (root.hostname !== 'deepwiki.org') {
+      if (root.hostname !== 'deepwiki.com') {
         const err: z.infer<typeof ErrorEnvelope> = {
           status: 'error',
           code: 'DOMAIN_NOT_ALLOWED',
-          message: 'Only deepwiki.org domains are allowed',
+          message: 'Only deepwiki.com domains are allowed',
         }
         return err
       }

--- a/src/tools/deepwikiSearch.ts
+++ b/src/tools/deepwikiSearch.ts
@@ -22,7 +22,7 @@ const SearchRequest = FetchRequest.extend({
 export function deepwikiSearchTool({ mcp }: McpToolContext) {
   mcp.tool(
     'deepwiki_search',
-    `Download pages from a deepwiki.org, look for a case-insensitive
+    `Download pages from a deepwiki.com, look for a case-insensitive
 substring, and return up to maxMatches short snippets with the match
 wrapped in **bold**.
 

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -64,7 +64,7 @@ describe('deepWiki Tool Tests', () => {
     }
   })
 
-  it('should fetch content from a deepwiki.org URL', async () => {
+  it('should fetch content from a deepwiki.com URL', async () => {
     await client.connectServer() // Connect with default settings
 
     // Verify deepwiki.fetch tool is available
@@ -74,7 +74,7 @@ describe('deepWiki Tool Tests', () => {
 
     // Call the deepwiki.fetch tool
     const result = await client.callTool('deepwiki.fetch', {
-      url: 'https://deepwiki.org/antiwork/gumroad/3.1-navigation-components',
+      url: 'https://deepwiki.com/antiwork/gumroad/3.1-navigation-components',
       maxDepth: 1,
       mode: 'pages',
     })
@@ -84,7 +84,7 @@ describe('deepWiki Tool Tests', () => {
     expect(result.content[0].text).toMatch(/Navigation Components/)
   }, 30000) // Increase timeout for network request
 
-  it('should return error for non-deepwiki.org URL', async () => {
+  it('should return error for non-deepwiki.com URL', async () => {
     await client.connectServer()
 
     // Expect the call to reject with a specific error structure

--- a/tests/crawler.test.ts
+++ b/tests/crawler.test.ts
@@ -7,7 +7,7 @@ import { htmlToMarkdown } from '../src/converter/htmlToMarkdown'
 import { crawl } from '../src/lib/httpCrawler'
 
 const OUTPUT_DIR = join(__dirname, 'output')
-const TARGET_URL = 'https://deepwiki.org/regenrek/codefetch'
+const TARGET_URL = 'https://deepwiki.com/regenrek/codefetch'
 const ROOT_URL = new URL(TARGET_URL)
 const ROOT_PATH = ROOT_URL.pathname
 
@@ -50,7 +50,7 @@ describe('crawl', () => {
     }
   })
 
-  it('crawls deepwiki.org (pages mode) and converts to markdown', async () => {
+  it('crawls deepwiki.com (pages mode) and converts to markdown', async () => {
     try {
       const { html, errors } = await crawl({
         root: ROOT_URL,
@@ -73,7 +73,7 @@ describe('crawl', () => {
     }
   }, 30000)
 
-  it('crawls deepwiki.org (aggregate mode) and converts to markdown', async () => {
+  it('crawls deepwiki.com (aggregate mode) and converts to markdown', async () => {
     try {
       const { html, errors } = await crawl({
         root: ROOT_URL,
@@ -102,7 +102,7 @@ describe('crawl depth', () => {
     mkdirSync(OUTPUT_DIR, { recursive: true })
   })
 
-  // it.each([0, 1, 2])('crawls deepwiki.org with maxDepth %i', async (maxDepth) => {
+  // it.each([0, 1, 2])('crawls deepwiki.com with maxDepth %i', async (maxDepth) => {
   //   try {
   //     const { html, errors } = await crawl({
   //       root: ROOT_URL,
@@ -123,7 +123,7 @@ describe('crawl depth', () => {
   //     expect.fail(`Test (depth ${maxDepth}) threw an error: ${error}`)
   //   }
   // }, 30000 * 5)
-  it.each([0, 1, 2])('crawls deepwiki.org with maxDepth %i', async (maxDepth) => {
+  it.each([0, 1, 2])('crawls deepwiki.com with maxDepth %i', async (maxDepth) => {
     try {
       const { html, errors } = await crawl({
         root: ROOT_URL,


### PR DESCRIPTION
# Summary

Updated domain references back to deepwiki.com across the codebase and documentation, including changelog and README. This release reflects the change in domain usage for the tool's functionality.