### PR TITLE
Fix Docker build by updating pnpm-lock.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV NODE_ENV=production
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/bin ./bin
-COPY --from=builder /app/package.json ./package.json # Good practice to include
+COPY --from=builder /app/package.json ./package.json
 
 # Set the entrypoint to your CLI script
 ENTRYPOINT ["node", "bin/cli.mjs"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       linkedom:
         specifier: ^0.18.9
         version: 0.18.9
+      mcp-deepwiki:
+        specifier: ^0.0.9
+        version: 0.0.9(@typescript-eslint/utils@8.30.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(jiti@2.4.2)(typescript@5.8.3)(vitest@3.1.1(@types/debug@4.1.12)(@types/node@22.14.1)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.1))
       ofetch:
         specifier: ^1.4.1
         version: 1.4.1
@@ -1863,6 +1866,11 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mcp-deepwiki@0.0.9:
+    resolution: {integrity: sha512-LSVdTyRRZHjroXla2T9rG3LPrOCv19gjSg53oqa1UMoXoWEFTkn7K8geg+4d6QF17iViUO/jNgRzCssvNO02HQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
@@ -4843,6 +4851,38 @@ snapshots:
   markdown-table@3.0.4: {}
 
   math-intrinsics@1.1.0: {}
+
+  mcp-deepwiki@0.0.9(@typescript-eslint/utils@8.30.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(jiti@2.4.2)(typescript@5.8.3)(vitest@3.1.1(@types/debug@4.1.12)(@types/node@22.14.1)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.1)):
+    dependencies:
+      '@chatmcp/sdk': 1.0.6
+      '@modelcontextprotocol/sdk': 1.9.0
+      '@vitest/eslint-plugin': 1.1.43(@typescript-eslint/utils@8.30.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3)(vitest@3.1.1(@types/debug@4.1.12)(@types/node@22.14.1)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.1))
+      citty: 0.1.6
+      eslint: 9.25.1(jiti@2.4.2)
+      h3: 1.15.1
+      hast-util-from-html: 2.0.3
+      hast-util-sanitize: 5.0.2
+      linkedom: 0.18.9
+      ofetch: 1.4.1
+      p-queue: 8.1.0
+      rehype-parse: 9.0.1
+      rehype-remark: 10.0.1
+      rehype-sanitize: 6.0.0
+      remark-gfm: 4.0.1
+      remark-stringify: 11.0.0
+      robots-parser: 3.0.1
+      undici: 7.8.0
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+      wink-eng-lite-web-model: 1.8.1
+      wink-nlp: 1.14.3
+      zod: 3.24.3
+    transitivePeerDependencies:
+      - '@typescript-eslint/utils'
+      - jiti
+      - supports-color
+      - typescript
+      - vitest
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:


### PR DESCRIPTION
## Problem
Docker build was failing with the following error:
```
ERR_PNPM_OUTDATED_LOCKFILE Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with <ROOT>/package.json
```
## Root Cause
The `pnpm-lock.yaml` file was outdated and missing the `mcp-deepwiki` dependency that was added to `package.json`.

## Solution
- Updated `pnpm-lock.yaml` to include the missing `mcp-deepwiki` dependency
- Removed unnecessary comment from Dockerfile

## Changes Made
- Added `mcp-deepwiki@^0.0.9` entry to pnpm-lock.yaml dependencies
- Minor formatting improvements to Dockerfile

## Testing
- [x] Docker build now completes successfully, test result [omegaatt36/mcp-deepwiki](https://hub.docker.com/repository/docker/omegaatt36/mcp-deepwiki)
- [x] No breaking changes to existing functionality
